### PR TITLE
Load the plugin config file before returning Config

### DIFF
--- a/lib/vagrant-registration/plugin.rb
+++ b/lib/vagrant-registration/plugin.rb
@@ -42,6 +42,7 @@ module VagrantPlugins
       action_hook(:registration_unregister, :machine_action_halt, &method(:unregister))
 
       config(:registration) do
+        require_relative 'config'
         Config
       end
 


### PR DESCRIPTION
The plugin would crash and won't load if we don't load the config properly.
