### PR TITLE
Add hooks for provision and destroy

### DIFF
--- a/lib/vagrant-registration/plugin.rb
+++ b/lib/vagrant-registration/plugin.rb
@@ -38,8 +38,10 @@ module VagrantPlugins
 
       #@logger.info("attempting to register hooks on ")
       action_hook(:registration_register, :machine_action_up, &method(:register))
+      action_hook(:registration_register, :machine_action_provision, &method(:register))
 
       action_hook(:registration_unregister, :machine_action_halt, &method(:unregister))
+      action_hook(:registration_unregister, :machine_action_destroy, &method(:unregister))
 
       config(:registration) do
         require_relative 'config'


### PR DESCRIPTION
Since we bind to specific action, I believe we need to register on provision and unregister on destroy as well.

I am unsure about reload/suspend/resume. Reload probably does not need anything and suspend/resume could register and unregister as well probably. Ideas?
