### PR TITLE
Show register/unregister on the screen

### DIFF
--- a/lib/vagrant-registration/action/register.rb
+++ b/lib/vagrant-registration/action/register.rb
@@ -16,6 +16,7 @@ module VagrantPlugins
           @logger.info("Testing for registration_register capability on ")
 
           if guest.capability?(:register)
+            env[:ui].info("Registering box with vagrant-registration...")
             @logger.info("registration_register capability exists on ")
             result = guest.capability(:register)
             @logger.info("called registration_register capability on ")

--- a/lib/vagrant-registration/action/unregister.rb
+++ b/lib/vagrant-registration/action/unregister.rb
@@ -14,6 +14,7 @@ module VagrantPlugins
           guest = @env[:machine].guest
           #   @logger.info("Testing for registration_unregister capability on ")
           if guest.capability?(:unregister)
+            env[:ui].info("Unregistering box with vagrant-registration...")
             @logger.info("registration_unregister capability exists on ")
             result = guest.capability(:unregister)
             @logger.info("called registration_unregister capability on ")


### PR DESCRIPTION
This PR informs users that (un)registration is happening:

```
$ vagrant up
Bringing machine 'default' up with 'libvirt' provider...
==> default: Starting domain.
==> default: Waiting for domain to get an IP address...
==> default: Waiting for SSH to become available...
==> default: Creating shared folders metadata...
==> default: Registering box with vagrant-registration...
```
