### PR TITLE
Unsupported configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,21 @@ Note that the `auto_attach` option is set to false when using org/activationkey 
   config.registration.skip
 ```
 
+## Tests
+
+Tests currently test the plugin with `subscription-manager` on RHEL 7.1 guest
+and Fedora host. You need an imported RHEL 7.1 Vagrant box named `rhel-7.1`.
+
+To run them:
+
+```
+export VAGRANT_REGISTRATION_USERNAME=
+export VAGRANT_REGISTRATION_PASSWORD=
+export VAGRANT_REGISTRATION_ORG=
+export VAGRANT_REGISTRATION_ACTIVATIONKEY=
+./tests/run.sh
+```
+
 ## Acknowledgements
 
 The project would like to make sure we thank [purpleidea](https://github.com/purpleidea/), [humaton](https://github.com/humaton/), [strzibny](https://github.com/strzibny), [scollier](https://github.com/scollier/), [puzzle](https://github.com/puzzle), [voxik](https://github.com/voxik), [lukaszachy](https://github.com/lukaszachy) and [goern](https://github.com/goern) (in no particular order) for their contributions of ideas, code and testing for this project.

--- a/lib/vagrant-registration.rb
+++ b/lib/vagrant-registration.rb
@@ -1,18 +1,14 @@
-require "pathname"
-
-require "vagrant-registration/plugin"
+require 'pathname'
+require 'vagrant-registration/plugin'
 
 module VagrantPlugins
   module Registration
-    lib_path = Pathname.new(File.expand_path("../vagrant-registration", __FILE__))
-    autoload :Action, lib_path.join("action")
-    #autoload :Errors, lib_path.join("errors")
+    lib_path = Pathname.new(File.expand_path('../vagrant-registration', __FILE__))
+    autoload :Action, lib_path.join('action')
 
     # This returns the path to the source of this plugin.
-    #
-    # @return [Pathname]
     def self.source_root
-      @source_root ||= Pathname.new(File.expand_path("../../", __FILE__))
+      @source_root ||= Pathname.new(File.expand_path('../../', __FILE__))
     end
 
     # Temporally load the extra capability files for Red Hat

--- a/lib/vagrant-registration/action.rb
+++ b/lib/vagrant-registration/action.rb
@@ -20,10 +20,10 @@ module VagrantPlugins
         end
       end
 
-      action_root = Pathname.new(File.expand_path("../action", __FILE__))
-      autoload :Register, action_root.join("register")
-      autoload :UnregisterOnHalt, action_root.join("unregister_on_halt")
-      autoload :UnregisterOnDestroy, action_root.join("unregister_on_destroy")
+      action_root = Pathname.new(File.expand_path('../action', __FILE__))
+      autoload :Register, action_root.join('register')
+      autoload :UnregisterOnHalt, action_root.join('unregister_on_halt')
+      autoload :UnregisterOnDestroy, action_root.join('unregister_on_destroy')
     end
   end
 end

--- a/lib/vagrant-registration/action/register.rb
+++ b/lib/vagrant-registration/action/register.rb
@@ -50,16 +50,29 @@ module VagrantPlugins
           !machine.guest.capability(:registration_registered?)
         end
 
-        # Issues warning if an unsupported option is used
+        # Issues warning if an unsupported option is used and displays
+        # a list of supported options
         def check_configuration_options(machine, ui)
+          manager = machine.guest.capability(:registration_manager).to_s
           available_options = machine.guest.capability(:registration_options)
-          machine.config.registration.conf.each_pair do |pair|
-            option = pair[0].to_sym
+          options = machine.config.registration.conf.each_pair.map { |pair| pair[0] }
+
+          if unsupported_options_provided?(manager, available_options, options, ui)
+            ui.warn("WARNING: #{manager} supports only the following options:" +
+                    "\nWARNING: " + available_options.join(', '))
+          end
+        end
+
+        # Return true if there are any unsupported options
+        def unsupported_options_provided?(manager, available_options, options, ui)
+          warned = false
+          options.each do |option|
             unless available_options.include? option
-              ui.warn("WARNING: #{option} option is not supported for " +
-                      machine.guest.capability(:registration_manager).to_s)
+              ui.warn("WARNING: #{option} option is not supported for " + manager)
+              warned = true
             end
           end
+          warned
         end
 
         # Check if registration capabilities are available

--- a/lib/vagrant-registration/action/register.rb
+++ b/lib/vagrant-registration/action/register.rb
@@ -56,7 +56,8 @@ module VagrantPlugins
           machine.config.registration.conf.each_pair do |pair|
             option = pair[0].to_sym
             unless available_options.include? option
-              ui.warn("WARNING: #{option} is not supported for a given subscription manager")
+              ui.warn("WARNING: #{option} option is not supported for " +
+                      machine.guest.capability(:registration_manager).to_s)
             end
           end
         end

--- a/lib/vagrant-registration/action/register.rb
+++ b/lib/vagrant-registration/action/register.rb
@@ -20,6 +20,7 @@ module VagrantPlugins
 
           if should_register?(machine)
             env[:ui].info("Registering box with vagrant-registration...")
+            check_configuration_options(machine, env[:ui])
 
             unless credentials_provided? machine
               @logger.debug("Credentials for registration not provided")
@@ -47,6 +48,17 @@ module VagrantPlugins
           capabilities_provided?(machine.guest) &&
           manager_installed?(machine.guest) &&
           !machine.guest.capability(:registration_registered?)
+        end
+
+        # Issues warning if an unsupported option is used
+        def check_configuration_options(machine, ui)
+          available_options = machine.guest.capability(:registration_options)
+          machine.config.registration.conf.each_pair do |pair|
+            option = pair[0].to_sym
+            unless available_options.include? option
+              ui.warn("WARNING: #{option} is not supported for a given subscription manager")
+            end
+          end
         end
 
         # Check if registration capabilities are available

--- a/lib/vagrant-registration/action/register.rb
+++ b/lib/vagrant-registration/action/register.rb
@@ -5,9 +5,9 @@ module VagrantPlugins
     module Action
       # This registers the guest if the guest plugin supports it
       class Register
-        def initialize(app, env)
+        def initialize(app, _)
           @app    = app
-          @logger = Log4r::Logger.new("vagrant_registration::action::register")
+          @logger = Log4r::Logger.new('vagrant_registration::action::register')
         end
 
         def call(env)
@@ -19,14 +19,14 @@ module VagrantPlugins
           guest = env[:machine].guest
 
           if should_register?(machine)
-            env[:ui].info("Registering box with vagrant-registration...")
+            env[:ui].info('Registering box with vagrant-registration...')
             check_configuration_options(machine, env[:ui])
 
             unless credentials_provided? machine
-              @logger.debug("Credentials for registration not provided")
+              @logger.debug('Credentials for registration not provided')
 
               # Offer to register ATM or skip
-              register_now = env[:ui].ask("Would you like to register the system now (default: yes)? [y|n] ")
+              register_now = env[:ui].ask('Would you like to register the system now (default: yes)? [y|n]')
 
               if register_now == 'n'
                 config.skip = true
@@ -37,7 +37,7 @@ module VagrantPlugins
             guest.capability(:registration_register) unless config.skip
           end
 
-          @logger.debug("Registration is skipped due to the configuration") if config.skip
+          @logger.debug('Registration is skipped due to the configuration') if config.skip
         end
 
         private
@@ -68,7 +68,7 @@ module VagrantPlugins
              guest.capability?(:registration_registered?)
             true
           else
-            @logger.debug("Registration is skipped due to the missing guest capability")
+            @logger.debug('Registration is skipped due to the missing guest capability')
             false
           end
         end
@@ -78,7 +78,7 @@ module VagrantPlugins
           if guest.capability(:registration_manager_installed)
             true
           else
-            @logger.debug("Registration manager not found on guest")
+            @logger.debug('Registration manager not found on guest')
             false
           end
         end
@@ -124,7 +124,7 @@ module VagrantPlugins
             unless machine.config.registration.send(option)
               echo = !(secrets(machine).include? option)
               response = ui.ask("#{option}: ", echo: echo)
-              machine.config.registration.send("#{option.to_s}=".to_sym, response)
+              machine.config.registration.send("#{option}=".to_sym, response)
             end
           end
           machine.config.registration

--- a/lib/vagrant-registration/action/unregister_on_destroy.rb
+++ b/lib/vagrant-registration/action/unregister_on_destroy.rb
@@ -1,4 +1,4 @@
-require "log4r"
+require 'log4r'
 
 module VagrantPlugins
   module Registration
@@ -7,7 +7,7 @@ module VagrantPlugins
       class UnregisterOnDestroy
         def initialize(app, env)
           @app    = app
-          @logger = Log4r::Logger.new("vagrant_registration::action::unregister_on_destroy")
+          @logger = Log4r::Logger.new('vagrant_registration::action::unregister_on_destroy')
         end
 
         def call(env)
@@ -15,17 +15,17 @@ module VagrantPlugins
           guest = env[:machine].guest
 
           if capabilities_provided?(guest) && manager_installed?(guest) && !config.skip
-            env[:ui].info("Unregistering box with vagrant-registration...")
+            env[:ui].info('Unregistering box with vagrant-registration...')
             guest.capability(:registration_unregister)
           end
 
-          @logger.debug("Unregistration is skipped due to the configuration") if config.skip
+          @logger.debug('Unregistration is skipped due to the configuration') if config.skip
           @app.call(env)
 
         # Guest might not be available after halting, so log the exception and continue
         rescue => e
           @logger.info(e)
-          @logger.debug("Guest is not available, ignore unregistration")
+          @logger.debug('Guest is not available, ignore unregistration')
           @app.call(env)
         end
 
@@ -36,7 +36,7 @@ module VagrantPlugins
           if guest.capability?(:registration_unregister) && guest.capability?(:registration_manager_installed)
             true
           else
-            @logger.debug("Unregistration is skipped due to the missing guest capability")
+            @logger.debug('Unregistration is skipped due to the missing guest capability')
             false
           end
         end
@@ -46,7 +46,7 @@ module VagrantPlugins
           if guest.capability(:registration_manager_installed)
             true
           else
-            @logger.debug("Registration manager not found on guest")
+            @logger.debug('Registration manager not found on guest')
             false
           end
         end

--- a/lib/vagrant-registration/action/unregister_on_halt.rb
+++ b/lib/vagrant-registration/action/unregister_on_halt.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
       class UnregisterOnHalt
         def initialize(app, env)
           @app    = app
-          @logger = Log4r::Logger.new("vagrant_registration::action::unregister_on_halt")
+          @logger = Log4r::Logger.new('vagrant_registration::action::unregister_on_halt')
         end
 
         def call(env)
@@ -15,18 +15,18 @@ module VagrantPlugins
           guest = env[:machine].guest
 
           if capabilities_provided?(guest) && manager_installed?(guest) && !config.skip && config.unregister_on_halt
-            env[:ui].info("Unregistering box with vagrant-registration...")
+            env[:ui].info('Unregistering box with vagrant-registration...')
             guest.capability(:registration_unregister)
           end
 
-          @logger.debug("Unregistration is skipped due to the configuration") if config.skip
-          @logger.debug("Unregistration is skipped on halt due to the configuration") if !config.unregister_on_halt
+          @logger.debug('Unregistration is skipped due to the configuration') if config.skip
+          @logger.debug('Unregistration is skipped on halt due to the configuration') if !config.unregister_on_halt
           @app.call(env)
 
         # Guest might not be available after halting, so log the exception and continue
         rescue => e
           @logger.info(e)
-          @logger.debug("Guest is not available, ignore unregistration")
+          @logger.debug('Guest is not available, ignore unregistration')
           @app.call(env)
         end
 
@@ -37,7 +37,7 @@ module VagrantPlugins
           if guest.capability?(:registration_unregister) && guest.capability?(:registration_manager_installed)
             true
           else
-            @logger.debug("Unregistration is skipped due to the missing guest capability")
+            @logger.debug('Unregistration is skipped due to the missing guest capability')
             false
           end
         end
@@ -47,7 +47,7 @@ module VagrantPlugins
           if guest.capability(:registration_manager_installed)
             true
           else
-            @logger.debug("Registration manager not found on guest")
+            @logger.debug('Registration manager not found on guest')
             false
           end
         end

--- a/lib/vagrant-registration/config.rb
+++ b/lib/vagrant-registration/config.rb
@@ -3,12 +3,12 @@ require "ostruct"
 
 module VagrantPlugins
   module Registration
-    class Config < Vagrant.plugin("2", :config)
+    class Config < Vagrant.plugin('2', :config)
       attr_reader :conf
 
       def initialize(region_specific=false)
         @conf = UNSET_VALUE
-        @logger = Log4r::Logger.new("vagrant_registration::config")
+        @logger = Log4r::Logger.new('vagrant_registration::config')
       end
 
       def finalize!
@@ -28,16 +28,16 @@ module VagrantPlugins
 
       private
 
-        # Don't set @conf to OpenStruct in initialize
-        # to preserve config hierarchy
-        def get_config
-          @conf = OpenStruct.new if @conf == UNSET_VALUE
-        end
+      # Don't set @conf to OpenStruct in initialize
+      # to preserve config hierarchy
+      def get_config
+        @conf = OpenStruct.new if @conf == UNSET_VALUE
+      end
 
-        def adjust_arguments(args)
-          return '' if args.size < 1
-          args.map{|a| a.is_a?(String) ? "'#{a}'" : a}.join(',')
-        end
+      def adjust_arguments(args)
+        return '' if args.size < 1
+        args.map { |a| a.is_a?(String) ? "'#{a}'" : a }.join(',')
+      end
     end
   end
 end

--- a/lib/vagrant-registration/config.rb
+++ b/lib/vagrant-registration/config.rb
@@ -4,6 +4,8 @@ require "ostruct"
 module VagrantPlugins
   module Registration
     class Config < Vagrant.plugin("2", :config)
+      attr_reader :conf
+
       def initialize(region_specific=false)
         @conf = UNSET_VALUE
         @logger = Log4r::Logger.new("vagrant_registration::config")

--- a/lib/vagrant-registration/plugin.rb
+++ b/lib/vagrant-registration/plugin.rb
@@ -6,13 +6,13 @@ end
 
 # This is a sanity check to make sure no one is attempting to install
 # this into an early Vagrant version.
-if Vagrant::VERSION < "1.2.0"
-  raise "The Vagrant RHEL plugin is only compatible with Vagrant 1.2+"
+if Vagrant::VERSION < '1.2.0'
+  fail 'The Vagrant RHEL plugin is only compatible with Vagrant 1.2+.'
 end
 
 module VagrantPlugins
   module Registration
-    class Plugin < Vagrant.plugin("2")
+    class Plugin < Vagrant.plugin('2')
       class << self
         def register(hook)
           setup_logging
@@ -31,7 +31,7 @@ module VagrantPlugins
         end
       end
 
-      name "Registration"
+      name 'Registration'
       description <<-DESC
       This plugin adds register and unregister functionality to Vagrant Guests that
       support the capability
@@ -64,7 +64,7 @@ module VagrantPlugins
         # Some constants, such as "true" resolve to booleans, so the
         # above error checking doesn't catch it. This will check to make
         # sure that the log level is an integer, as Log4r requires.
-        level = nil if !level.is_a?(Integer)
+        level = nil unless level.is_a?(Integer)
         # Set the logging level on all "vagrant" namespaced
         # logs as long as we have a valid level.
         if level

--- a/lib/vagrant-registration/version.rb
+++ b/lib/vagrant-registration/version.rb
@@ -1,5 +1,6 @@
 module VagrantPlugins
+  # Registration plugin to auto-register guests on `vagrant up`
   module Registration
-    VERSION = "0.0.19"
+    VERSION = '0.0.19'
   end
 end

--- a/plugins/guests/redhat/cap/registration.rb
+++ b/plugins/guests/redhat/cap/registration.rb
@@ -1,6 +1,9 @@
 module VagrantPlugins
   module GuestRedHat
     module Cap
+      # Common configuration options for all managers
+      DEFAULT_CONFIGURATION_OPTIONS = [:skip, :unregister_on_halt]
+
       # This provides registration capabilities for vagrant-registration
       #
       # As we might support more registration options (managers), this
@@ -59,6 +62,17 @@ module VagrantPlugins
             machine.guest.capability(cap)
           else
             []
+          end
+        end
+
+        # Return all available options for a given registration manager together
+        # with general options available to any.
+        def self.registration_options(machine)
+          cap = "#{self.registration_manager(machine).to_s}_options".to_sym
+          if machine.guest.capability?(cap)
+            DEFAULT_CONFIGURATION_OPTIONS + machine.guest.capability(cap)
+          else
+            DEFAULT_CONFIGURATION_OPTIONS
           end
         end
 

--- a/plugins/guests/redhat/cap/subscription_manager.rb
+++ b/plugins/guests/redhat/cap/subscription_manager.rb
@@ -30,6 +30,13 @@ module VagrantPlugins
           [[:username, :password], [:org, :activationkey]]
         end
 
+        # Return all available options for subscription-manager
+        def self.subscription_manager_options(machine)
+          [:username, :password, :serverurl, :baseurl, :org, :environment,
+           :name, :auto_attach, :activationkey, :servicelevel, :release,
+           :force, :type]
+        end
+
         # Return secret options for subscription-manager
         def self.subscription_manager_secrets(machine)
           [:password]

--- a/plugins/guests/redhat/plugin.rb
+++ b/plugins/guests/redhat/plugin.rb
@@ -28,6 +28,11 @@ module VagrantPlugins
         Cap::Registration
       end
 
+      guest_capability("redhat", "registration_options") do
+        require_relative "cap/registration"
+        Cap::Registration
+      end
+
       guest_capability("redhat", "registration_secrets") do
         require_relative "cap/registration"
         Cap::Registration
@@ -59,6 +64,11 @@ module VagrantPlugins
       end
 
       guest_capability("redhat", "subscription_manager_credentials") do
+        require_relative "cap/subscription_manager"
+        Cap::SubscriptionManager
+      end
+
+      guest_capability("redhat", "subscription_manager_options") do
         require_relative "cap/subscription_manager"
         Cap::SubscriptionManager
       end

--- a/plugins/guests/redhat/plugin.rb
+++ b/plugins/guests/redhat/plugin.rb
@@ -1,80 +1,80 @@
-require "vagrant"
+require 'vagrant'
 
 module VagrantPlugins
   module GuestRedHat
-    class Plugin < Vagrant.plugin("2")
-      guest_capability("redhat", "registration_registered?") do
-        require_relative "cap/registration"
+    class Plugin < Vagrant.plugin('2')
+      guest_capability('redhat', 'registration_registered?') do
+        require_relative 'cap/registration'
         Cap::Registration
       end
 
-      guest_capability("redhat", "registration_register") do
-        require_relative "cap/registration"
+      guest_capability('redhat', 'registration_register') do
+        require_relative 'cap/registration'
         Cap::Registration
       end
 
-      guest_capability("redhat", "registration_unregister") do
-        require_relative "cap/registration"
+      guest_capability('redhat', 'registration_unregister') do
+        require_relative 'cap/registration'
         Cap::Registration
       end
 
-      guest_capability("redhat", "registration_manager_installed") do
-        require_relative "cap/registration"
+      guest_capability('redhat', 'registration_manager_installed') do
+        require_relative 'cap/registration'
         Cap::Registration
       end
 
-      guest_capability("redhat", "registration_credentials") do
-        require_relative "cap/registration"
+      guest_capability('redhat', 'registration_credentials') do
+        require_relative 'cap/registration'
         Cap::Registration
       end
 
-      guest_capability("redhat", "registration_options") do
-        require_relative "cap/registration"
+      guest_capability('redhat', 'registration_options') do
+        require_relative 'cap/registration'
         Cap::Registration
       end
 
-      guest_capability("redhat", "registration_secrets") do
-        require_relative "cap/registration"
+      guest_capability('redhat', 'registration_secrets') do
+        require_relative 'cap/registration'
         Cap::Registration
       end
 
-      guest_capability("redhat", "registration_manager") do
-        require_relative "cap/registration"
+      guest_capability('redhat', 'registration_manager') do
+        require_relative 'cap/registration'
         Cap::Registration
       end
 
-      guest_capability("redhat", "subscription_manager") do
-        require_relative "cap/subscription_manager"
+      guest_capability('redhat', 'subscription_manager') do
+        require_relative 'cap/subscription_manager'
         Cap::SubscriptionManager
       end
 
-      guest_capability("redhat", "subscription_manager_registered?") do
-        require_relative "cap/subscription_manager"
+      guest_capability('redhat', 'subscription_manager_registered?') do
+        require_relative 'cap/subscription_manager'
         Cap::SubscriptionManager
       end
 
-      guest_capability("redhat", "subscription_manager_register") do
-        require_relative "cap/subscription_manager"
+      guest_capability('redhat', 'subscription_manager_register') do
+        require_relative 'cap/subscription_manager'
         Cap::SubscriptionManager
       end
 
-      guest_capability("redhat", "subscription_manager_unregister") do
-        require_relative "cap/subscription_manager"
+      guest_capability('redhat', 'subscription_manager_unregister') do
+        require_relative 'cap/subscription_manager'
         Cap::SubscriptionManager
       end
 
-      guest_capability("redhat", "subscription_manager_credentials") do
-        require_relative "cap/subscription_manager"
+      guest_capability('redhat', 'subscription_manager_credentials') do
+        require_relative 'cap/subscription_manager'
         Cap::SubscriptionManager
       end
 
-      guest_capability("redhat", "subscription_manager_options") do
-        require_relative "cap/subscription_manager"
+      guest_capability('redhat', 'subscription_manager_options') do
+        require_relative 'cap/subscription_manager'
         Cap::SubscriptionManager
       end
 
-      guest_capability("redhat", "subscription_manager_secrets") do
-        require_relative "cap/subscription_manager"
+      guest_capability('redhat', 'subscription_manager_secrets') do
+        require_relative 'cap/subscription_manager'
         Cap::SubscriptionManager
       end
     end

--- a/tests/vagrantfiles/Vagrantfile.rhel_multi_machine
+++ b/tests/vagrantfiles/Vagrantfile.rhel_multi_machine
@@ -1,7 +1,7 @@
 # Spin 3 RHEL machines that will be registered
 
 ENV['VAGRANT_DEFAULT_PROVIDER'] ||= 'libvirt'
-ENV['VAGRANT_REGISTRATION_RHEL_BOX'] ||= 'rhel-7.0'
+ENV['VAGRANT_REGISTRATION_RHEL_BOX'] ||= 'rhel-7.1'
 
 Vagrant.configure('2') do |config|
   config.vm.box = ENV['VAGRANT_REGISTRATION_RHEL_BOX']

--- a/tests/vagrantfiles/Vagrantfile.rhel_wrong_credentials
+++ b/tests/vagrantfiles/Vagrantfile.rhel_wrong_credentials
@@ -1,7 +1,7 @@
 # Spin 1 RHEL machine with wrong credentials
 
 ENV['VAGRANT_DEFAULT_PROVIDER'] ||= 'libvirt'
-ENV['VAGRANT_REGISTRATION_RHEL_BOX'] ||= 'rhel-7.0'
+ENV['VAGRANT_REGISTRATION_RHEL_BOX'] ||= 'rhel-7.1'
 
 Vagrant.configure('2') do |config|
   config.vm.box = ENV['VAGRANT_REGISTRATION_RHEL_BOX']


### PR DESCRIPTION
This adds warnings about unsupported configuration being used:
```
==> default: Registering box with vagrant-registration...
==> default: WARNING: i_dont_exist option is not supported for subscription_manager
==> default: WARNING: subscription_manager supports only the following options:
==> default: WARNING: skip, unregister_on_halt, username, password, serverurl, baseurl, org, environment, name, auto_attach, activationkey, servicelevel, release, force, type
```
This will help us with API changes during upgrades.

Fixes #39 