### PR TITLE
Support uploading of custom ca cert file

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ Note that the `auto_attach` option is set to false when using org/activationkey 
   # Asset Manager, defaults to Customer Portal Subscription Management)
   config.registration.serverurl
 
-  # A path to a CA certificate, this file would be copied to /etc/rhsm/ca
+  # A path to a CA certificate, this file would be copied to /etc/rhsm/ca and
+  # if the file does not have .pem extension, it will be automatically added
   config.registration.ca_cert
 
   # Give the hostname of the content delivery server to use to receive updates

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ Note that the `auto_attach` option is set to false when using org/activationkey 
   # Asset Manager, defaults to Customer Portal Subscription Management)
   config.registration.serverurl
 
+  # A path to a CA certificate, this file would be copied to /etc/rhsm/ca
+  config.registration.ca_cert
+
   # Give the hostname of the content delivery server to use to receive updates
   # (required for Satellite 6)
   config.registration.baseurl

--- a/lib/vagrant-registration/action/register.rb
+++ b/lib/vagrant-registration/action/register.rb
@@ -34,7 +34,7 @@ module VagrantPlugins
                 config = register_on_screen(machine, env[:ui])
               end
             end
-            guest.capability(:registration_register) unless config.skip
+            guest.capability(:registration_register, env[:ui]) unless config.skip
           end
 
           @logger.debug('Registration is skipped due to the configuration') if config.skip

--- a/plugins/guests/redhat/cap/registration.rb
+++ b/plugins/guests/redhat/cap/registration.rb
@@ -21,10 +21,10 @@ module VagrantPlugins
         end
 
         # Register the given machine
-        def self.registration_register(machine)
+        def self.registration_register(machine, ui)
           cap = "#{self.registration_manager(machine).to_s}_register".to_sym
           if machine.guest.capability?(cap)
-            machine.guest.capability(cap, machine.config.registration)
+            machine.guest.capability(cap, ui)
           else
             false
           end

--- a/plugins/guests/redhat/cap/subscription_manager.rb
+++ b/plugins/guests/redhat/cap/subscription_manager.rb
@@ -22,11 +22,15 @@ module VagrantPlugins
         end
 
         # Upload provided CA cert to the standard /etc/rhsm/ca path on the guest
+        #
+        # Since subscription-manager recognizes only .pem files, we rename those
+        # files not ending with '.pem' extension.
         def self.subscription_manager_upload_certificate(machine, ui)
           ui.info("Uploading CA certificate from #{machine.config.registration.ca_cert}...")
           if File.exist?(machine.config.registration.ca_cert)
             cert_file_content = File.read(machine.config.registration.ca_cert)
             cert_file_name = File.basename(machine.config.registration.ca_cert)
+            cert_file_name = "#{cert_file_name}.pem" unless cert_file_name.end_with? '.pem'
             machine.communicate.execute("echo '#{cert_file_content}' > /etc/rhsm/ca/#{cert_file_name}", sudo: true)
           else
             ui.warn("WARNING: Provided CA certificate file #{machine.config.registration.ca_cert} does not exist, skipping")

--- a/plugins/guests/redhat/cap/subscription_manager.rb
+++ b/plugins/guests/redhat/cap/subscription_manager.rb
@@ -15,10 +15,23 @@ module VagrantPlugins
         end
 
         # Register the machine using 'register' option, config is (Open)Struct
-        def self.subscription_manager_register(machine, config)
-          command = "subscription-manager register #{configuration_to_options(config)}"
+        def self.subscription_manager_register(machine, ui)
+          subscription_manager_upload_certificate(machine, ui) if machine.config.registration.ca_cert
+          command = "subscription-manager register #{configuration_to_options(machine.config.registration)}"
           machine.communicate.execute("cmd=$(#{command}); if [ \"$?\" != \"0\" ]; then echo $cmd | grep 'This system is already registered' || (echo $cmd 1>&2 && exit 1) ; fi", sudo: true)
         end
+
+        # Upload provided CA cert to the standard /etc/rhsm/ca path on the guest
+        def self.subscription_manager_upload_certificate(machine, ui)
+          ui.info("Uploading CA certificate from #{machine.config.registration.ca_cert}...")
+          if File.exist?(machine.config.registration.ca_cert)
+            cert_file_content = File.read(machine.config.registration.ca_cert)
+            cert_file_name = File.basename(machine.config.registration.ca_cert)
+            machine.communicate.execute("echo '#{cert_file_content}' > /etc/rhsm/ca/#{cert_file_name}", sudo: true)
+          else
+            ui.warn("WARNING: Provided CA certificate file #{machine.config.registration.ca_cert} does not exist, skipping")
+          end
+       end
 
         # Unregister the machine using 'unregister' option
         def self.subscription_manager_unregister(machine)
@@ -31,10 +44,13 @@ module VagrantPlugins
         end
 
         # Return all available options for subscription-manager
+        #
+        # ca_cert is not part of 'register' command API, but it's needed
+        # in conjuntion with serverurl option.
         def self.subscription_manager_options(machine)
           [:username, :password, :serverurl, :baseurl, :org, :environment,
            :name, :auto_attach, :activationkey, :servicelevel, :release,
-           :force, :type]
+           :force, :type, :ca_cert]
         end
 
         # Return secret options for subscription-manager

--- a/plugins/guests/redhat/plugin.rb
+++ b/plugins/guests/redhat/plugin.rb
@@ -58,6 +58,11 @@ module VagrantPlugins
         Cap::SubscriptionManager
       end
 
+      guest_capability('redhat', 'subscription_manager_upload_certificate') do
+        require_relative "cap/subscription_manager"
+        Cap::SubscriptionManager
+      end
+
       guest_capability('redhat', 'subscription_manager_unregister') do
         require_relative 'cap/subscription_manager'
         Cap::SubscriptionManager


### PR DESCRIPTION
Add `ca_cert` option to subscription-manager configuration.

If specified it copies the provided `.pem` file to `/etc/rhsm/ca` before attempting to register.

This solves #38 