### PR TITLE
Feature/support rhn register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Print warning if specifically selected manager is not available
 - Support running alongside vagrant-vbguest
+- Added rhn_register manager
 
 ## 1.0.1
 

--- a/README.md
+++ b/README.md
@@ -290,6 +290,13 @@ export VAGRANT_REGISTRATION_CA_CERT=
 ./tests/run.sh
 ```
 
+To show the vagrant output on the console during the tests run, set the `DEBUG`
+environment variable on `1` before executing the test script:
+
+```
+export DEBUG=1
+```
+
 ## Acknowledgements
 
 The project would like to make sure we thank [purpleidea](https://github.com/purpleidea/), [humaton](https://github.com/humaton/), [strzibny](https://github.com/strzibny), [scollier](https://github.com/scollier/), [puzzle](https://github.com/puzzle), [voxik](https://github.com/voxik), [lukaszachy](https://github.com/lukaszachy) and [goern](https://github.com/goern) (in no particular order) for their contributions of ideas, code and testing for this project.

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ end
 
 If you do not provide credentials, you will be prompted for them in the "up process."
 
-Please note the the interactive mode asks you for the preferred registration pair only.
-In case of a subscription-manager, you would be ask on your username/password combination.
+Please note the the interactive mode asks you for the preferred registration pair only
+of the configured manager.
 
 ### subscription-manager Configuration
 
@@ -109,6 +109,9 @@ Vagrant.configure('2') do |config|
 ...
 end
 ```
+
+In case of `subscription_manager` manager for the preferred registration pair,
+you would be ask on your username/password combination.
 
 vagrant-registration supports all the options of subscription-manager's register command.
 You can set any option easily by setting `config.registration.OPTION_NAME = 'OPTION_VALUE'`
@@ -202,6 +205,9 @@ Vagrant.configure('2') do |config|
 end
 ```
 
+In case of a `rhn_register` manager for the preferred registration pair,
+you would be ask on your username/password/serverurl combination.
+
 vagrant-registration supports all the options of rhnreg_ks's command.
 You can set any option easily by setting `config.registration.OPTION_NAME = 'OPTION_VALUE'`
 in your Vagrantfile (please see the rhnreg_ks's documentation for option description).
@@ -232,10 +238,21 @@ options where possible.
   # Give the URL of the subscription service to use (required for registering a
   # system with the "Spacewalk Server", "Red Hat Satellite" or "Red Hat Network Classic").
   # The configuration name is mapped to the `--serverUrl` option of rhnreg_ks command.
+  #
+  # The serverurl is mandatory and if you do not provide a value,
+  # you will be prompted for them in the "up process."
   config.registration.serverurl
 
-  # A path to a CA certificate, this file would be copied to /usr/share/rhn/
+  # A path to a CA certificate file (optional)
   # The configuration name is mapped to the `--sslCACert` option of rhnreg_ks command.
+  #
+  # The CA certificate file is be uploaded to /usr/share/rhn/<ca_file_name> in guest
+  # and the configuration  in `/etc/sysconfig/rhn/up2date` is updated to:
+  # `sslCACert=/usr/share/rhn/<ca_file_name>`
+  #
+  # As default only the configuration in `/etc/sysconfig/rhn/up2date` is updated
+  # to point to the CA certificate file that is present on Fedora, CentOS and RHEL:
+  # `sslCACert=/usr/share/rhn/RHNS-CA-CERT`
   config.registration.ca_cert
 
   # Give the organization to which to join the system (required, except for

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ end
   config.registration.unregister_on_halt = false
 ```
 
-- **manager** select the registration manager implementation. By default the plugin will use the implementation for the subscription-manager's register command, you can however change that by setting the option to a different implementation:
+- **manager** select the registration manager provider. By default the plugin will use the `subscription_manager` manager, you can however change that by setting the option to a different manager:
 
 ```ruby
-  config.registration.manager = subscription_manager
+  config.registration.manager = 'subscription_manager'
 ```
 
 ### Credentials Configuration
@@ -98,7 +98,7 @@ In case of a subscription-manager, you would be ask on your username/password co
 
 ### subscription-manager Configuration
 
-vagrant-registration will use the subscription-manager registration manager implementation by default or can be explicitly configured by setting the `mananager` option to `subscription_manager`:
+vagrant-registration will use the `subscription_manager` manager by default or can be explicitly configured by setting the `mananager` option to `subscription_manager`:
 
 ```ruby
 Vagrant.configure('2') do |config|
@@ -190,7 +190,7 @@ Note that the `auto_attach` option is set to false when using org/activationkey 
 
 ### rhn-register Configuration
 
-vagrant-registration will use the rhn-register registration manager implementation only if explicitly configured by setting the `mananager` option to `rhn_register`:
+vagrant-registration will use the `rhn_register` manager only if explicitly configured by setting the `mananager` option to `rhn_register`:
 
 ```ruby
 Vagrant.configure('2') do |config|
@@ -206,7 +206,7 @@ vagrant-registration supports all the options of rhnreg_ks's command.
 You can set any option easily by setting `config.registration.OPTION_NAME = 'OPTION_VALUE'`
 in your Vagrantfile (please see the rhnreg_ks's documentation for option description).
 To reduce the number of accepted options for configuring the plugin,
-the options for `rhn-register` manager will reuse the naming of `subscription-manager`'s command
+the options for `rhn_register` manager will reuse the naming of `subscription-manager`'s command
 options where possible.
 
 #### rhn-register Default Options

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ options where possible.
   # This is an unencrypted password.
   config.registration.password
 
-  # Give the URL of the subscription service to use (required for  registering a
+  # Give the URL of the subscription service to use (required for registering a
   # system with the "Spacewalk Server", "Red Hat Satellite" or "Red Hat Network Classic").
   # The configuration name is mapped to the `--serverUrl` option of rhnreg_ks command.
   config.registration.serverurl
@@ -285,6 +285,8 @@ export VAGRANT_REGISTRATION_USERNAME=
 export VAGRANT_REGISTRATION_PASSWORD=
 export VAGRANT_REGISTRATION_ORG=
 export VAGRANT_REGISTRATION_ACTIVATIONKEY=
+export VAGRANT_REGISTRATION_SERVERURL=
+export VAGRANT_REGISTRATION_CA_CERT=
 ./tests/run.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,12 +47,13 @@ end
   config.registration.unregister_on_halt = false
 ```
 
-### subscription-manager Configuration
+- **manager** select the registration manager implementation. By default the plugin will use the implementation for the subscription-manager's register command, you can however change that by setting the option to a different implementation:
 
-vagrant-registration supports all the options of subscription-manager's register command.
-You can set any option easily by setting `config.registration.OPTION_NAME = 'OPTION_VALUE'`
-in your Vagrantfile (please see the subscription-manager's documentation for option
-description).
+```ruby
+  config.registration.manager = subscription_manager
+```
+
+### Credentials Configuration
 
 Setting up the credentials can be done as follows:
 
@@ -63,7 +64,7 @@ Vagrant.configure('2') do |config|
     config.registration.username = 'foo'
     config.registration.password = 'bar'
   end
-  
+
   # Alternatively
   if Vagrant.has_plugin?('vagrant-registration')
     config.registration.org = 'foo'
@@ -95,6 +96,25 @@ If you do not provide credentials, you will be prompted for them in the "up proc
 Please note the the interactive mode asks you for the preferred registration pair only.
 In case of a subscription-manager, you would be ask on your username/password combination.
 
+### subscription-manager Configuration
+
+vagrant-registration will use the subscription-manager registration manager implementation by default or can be explicitly configured by setting the `mananager` option to `subscription_manager`:
+
+```ruby
+Vagrant.configure('2') do |config|
+...
+  if Vagrant.has_plugin?('vagrant-registration')
+    config.registration.manager = 'subscription_manager'
+  end
+...
+end
+```
+
+vagrant-registration supports all the options of subscription-manager's register command.
+You can set any option easily by setting `config.registration.OPTION_NAME = 'OPTION_VALUE'`
+in your Vagrantfile (please see the subscription-manager's documentation for option
+description).
+
 #### subscription-manager Default Options
 
 - **--force**: Subscription Manager will fail if you attempt to register an already registered machine (see the man page for explanation), therefore vagrant-registration appends the `--force` flag automatically when subscribing. If you would like to disable this feature, set `force` option to `false`:
@@ -102,9 +122,9 @@ In case of a subscription-manager, you would be ask on your username/password co
 ```ruby
   config.registration.force = false
 ```
+
 - **--auto-attach**: Vagrant would fail to install packages on registered RHEL system if the subscription is not attached, therefore vagrant-registration appends the
 `--auto-attach` flag automatically when subscribing. To disable this option, set `auto_attach` option to `false`:
-
 
 ```ruby
   config.registration.auto_attach = false
@@ -168,6 +188,90 @@ Note that the `auto_attach` option is set to false when using org/activationkey 
   config.registration.skip
 ```
 
+### rhn-register Configuration
+
+vagrant-registration will use the rhn-register registration manager implementation only if explicitly configured by setting the `mananager` option to `rhn_register`:
+
+```ruby
+Vagrant.configure('2') do |config|
+...
+  if Vagrant.has_plugin?('vagrant-registration')
+    config.registration.manager = 'rhn_register'
+  end
+...
+end
+```
+
+vagrant-registration supports all the options of rhnreg_ks's command.
+You can set any option easily by setting `config.registration.OPTION_NAME = 'OPTION_VALUE'`
+in your Vagrantfile (please see the rhnreg_ks's documentation for option description).
+To reduce the number of accepted options for configuring the plugin,
+the options for `rhn-register` manager will reuse the naming of `subscription-manager`'s command
+options where possible.
+
+#### rhn-register Default Options
+
+- **--force**: rhnreg_ks command will fail if you attempt to register an already registered machine (see the man page for explanation), therefore vagrant-registration appends the `--force` flag automatically when subscribing. If you would like to disable this feature, set `force` option to `false`:
+
+```ruby
+  config.registration.force = false
+```
+
+#### rhn-register Options Reference
+
+```ruby
+  # The username to register the system with under Spacewalk Server, Red Hat Satellite or
+  # Red Hat Network Classic. This can be an existing Spacewalk, Red Hat Satellite or
+  # Red Hat Network Classic username, or a new  user‐name.
+  config.registration.username
+
+  # The password associated with the username specified with the `--username` option.
+  # This is an unencrypted password.
+  config.registration.password
+
+  # Give the URL of the subscription service to use (required for  registering a
+  # system with the "Spacewalk Server", "Red Hat Satellite" or "Red Hat Network Classic").
+  # The configuration name is mapped to the `--serverUrl` option of rhnreg_ks command.
+  config.registration.serverurl
+
+  # A path to a CA certificate, this file would be copied to /usr/share/rhn/
+  # The configuration name is mapped to the `--sslCACert` option of rhnreg_ks command.
+  config.registration.ca_cert
+
+  # Give the organization to which to join the system (required, except for
+  # hosted environments)
+  # The configuration name is mapped to the `--systemorgid` option of rhnreg_ks command.
+  config.registration.org
+
+  # Name of the subscribed system (optional, defaults to hostname if unset)
+  # The configuration name is mapped to the `--profilename` option of rhnreg_ks command.
+  config.registration.name
+
+  # Attach existing subscriptions as part of the registration process (optional)
+  config.registration.activationkey
+
+  # Subscribe this system to the EUS channel tied to the system's redhat-release (optional)
+  config.registration.use_eus_channel
+
+  # Do not probe or upload any hardware info (optional)
+  config.registration.nohardware
+
+  #  Do not profile or upload any package info (optional)
+  config.registration.nopackages
+
+  # Do not upload any virtualization info (optional)
+  config.registration.novirtinfo
+
+  # Do not start rhnsd after completion (optional)
+  config.registration.norhnsd
+
+  # Force the registration (optional, force if true, defaults to true)
+  config.registration.force
+
+  # Skip the registration (optional, skip if true, defaults to false)
+  config.registration.skip
+```
+
 ## Tests
 
 Tests currently test the plugin with `subscription-manager` on RHEL 7.1 guest
@@ -176,6 +280,7 @@ and Fedora host. You need an imported RHEL 7.1 Vagrant box named `rhel-7.1`.
 To run them:
 
 ```
+export VAGRANT_REGISTRATION_MANAGER=
 export VAGRANT_REGISTRATION_USERNAME=
 export VAGRANT_REGISTRATION_PASSWORD=
 export VAGRANT_REGISTRATION_ORG=

--- a/plugins/guests/redhat/cap/rhn_register.rb
+++ b/plugins/guests/redhat/cap/rhn_register.rb
@@ -41,12 +41,12 @@ module VagrantPlugins
         end
 
         # Return required configuration options for rhn register
-        def self.rhn_register_credentials(_)
+        def self.rhn_register_credentials(machine)
           [[:username, :password], [:org, :activationkey]]
         end
 
         # Return all available options for rhn register
-        def self.rhn_register_options(_)
+        def self.rhn_register_options(machine)
           [:name, :username, :password, :org, :serverurl,
            :ca_cert, :activationkey, :use_eus_channel,
            :nohardware, :nopackages, :novirtinfo, :norhnsd,
@@ -54,7 +54,7 @@ module VagrantPlugins
         end
 
         # Return secret options for rhreg_ks
-        def self.rhn_register_secrets(_)
+        def self.rhn_register_secrets(manager)
           [:password]
         end
 

--- a/plugins/guests/redhat/cap/rhn_register.rb
+++ b/plugins/guests/redhat/cap/rhn_register.rb
@@ -25,23 +25,18 @@ module VagrantPlugins
 
         # Unregister the machine using 'rhn_unregister.py' resource script
         def self.rhn_register_unregister(machine)
-          tmp = '/tmp/rhn_unregister'
-          username = machine.config.registration.username
-          password = machine.config.registration.password
-
           machine.communicate.tap do |comm|
-            # No api call can be made without username/password
-            if username && password
-              serverurl = machine.config.registration.serverurl
-              # Generate the api url
-              serverurl = serverurl.sub(/XMLRPC$/, 'rpc/api')
-              comm.sudo("rm -f #{tmp}", error_check: false)
-              comm.upload(resource('rhn_unregister.py'), tmp)
-              comm.sudo("python #{tmp} -u #{username} -p #{password} -s #{serverurl}")
-              comm.sudo("rm -f #{tmp}")
-            end
+            tmp = '/tmp/rhn_unregister'
+            system_id = '/etc/sysconfig/rhn/systemid'
+            server_url = machine.config.registration.serverurl
+            # Generate the api url
+            server_url = server_url.sub(/XMLRPC$/, 'rpc/api')
+            comm.sudo("rm -f #{tmp}", error_check: false)
+            comm.upload(resource('rhn_unregister.py'), tmp)
+            comm.sudo("python #{tmp} -s #{server_url} -f #{system_id}")
+            comm.sudo("rm -f #{tmp}")
             # guest still "thinks" it is a part of RHN network until systemdid file is removed
-            comm.sudo('rm -f /etc/sysconfig/rhn/systemid')
+            comm.sudo("rm -f #{system_id}")
           end
         end
 

--- a/plugins/guests/redhat/cap/rhn_register.rb
+++ b/plugins/guests/redhat/cap/rhn_register.rb
@@ -1,0 +1,121 @@
+module VagrantPlugins
+  module GuestRedHat
+    module Cap
+      class RhnRegister
+        # Test that the machine is already registered
+        def self.rhn_register_registered?(machine)
+          true if machine.communicate.execute('/usr/sbin/rhn_check', sudo: true)
+        rescue
+          false
+        end
+
+        # Test that we have rhn installed
+        def self.rhn_register(machine)
+          machine.communicate.test('/usr/sbin/rhn_check --version', sudo: true) &&
+            machine.communicate.test('/usr/sbin/rhnreg_ks --version', sudo: true)
+        end
+
+        # Register the machine using 'rhnreg_ks' command, config is (Open)Struct
+        def self.rhn_register_register(machine, ui)
+          rhn_register_upload_certificate(machine, ui) if machine.config.registration.ca_cert
+          rhn_register_server_url(machine, ui) if machine.config.registration.serverurl
+          command = "rhnreg_ks #{configuration_to_options(machine.config.registration)}"
+          machine.communicate.execute("cmd=$(#{command}); if [ \"$?\" != \"0\" ]; then echo $cmd | grep 'This system is already registered' || (echo $cmd 1>&2 && exit 1) ; fi", sudo: true)
+        end
+
+        # Unregister the machine using 'rhn_unregister.py' resource script
+        def self.rhn_register_unregister(machine)
+          tmp = '/tmp/rhn_unregister'
+          username = machine.config.registration.username
+          password = machine.config.registration.password
+
+          machine.communicate.tap do |comm|
+            # No api call can be made without username/password
+            if username && password
+              serverurl = machine.config.registration.serverurl
+              # Generate the api url
+              serverurl = serverurl.sub(/XMLRPC$/, 'rpc/api')
+              comm.sudo("rm -f #{tmp}", error_check: false)
+              comm.upload(resource('rhn_unregister.py'), tmp)
+              comm.sudo("python #{tmp} -u #{username} -p #{password} -s #{serverurl}")
+              comm.sudo("rm -f #{tmp}")
+            end
+            # guest still "thinks" it is a part of RHN network until systemdid file is removed
+            comm.sudo('rm -f /etc/sysconfig/rhn/systemid')
+          end
+        end
+
+        # Return required configuration options for rhn register
+        def self.rhn_register_credentials(_)
+          [[:username, :password], [:org, :activationkey]]
+        end
+
+        # Return all available options for rhn register
+        def self.rhn_register_options(_)
+          [:name, :username, :password, :org, :serverurl,
+           :ca_cert, :activationkey, :use_eus_channel,
+           :nohardware, :nopackages, :novirtinfo, :norhnsd,
+           :force]
+        end
+
+        # Return secret options for rhreg_ks
+        def self.rhn_register_secrets(_)
+          [:password]
+        end
+
+        private
+
+        # Upload provided SSL CA cert to the standard /usr/share/rhn/ path on the guest
+        def self.rhn_register_upload_certificate(machine, ui)
+          ui.info("Uploading CA certificate from #{machine.config.registration.ca_cert}...")
+          if File.exist?(machine.config.registration.ca_cert)
+            cert_file_content = File.read(machine.config.registration.ca_cert)
+            cert_file_name = File.basename(machine.config.registration.ca_cert)
+            machine.communicate.execute("echo '#{cert_file_content}' > /usr/share/rhn/#{cert_file_name}", sudo: true)
+            machine.communicate.execute("sed -i 's|^sslCACert=.*$|sslCACert=/usr/share/rhn/#{cert_file_name}|' /etc/sysconfig/rhn/up2date", sudo: true)
+          else
+            ui.warn("WARNING: Provided CA certificate file #{machine.config.registration.ca_cert} does not exist, skipping")
+          end
+        end
+
+        # Update configuration file '/etc/sysconfig/rhn/up2date' with
+        # provided server URL
+        def self.rhn_register_server_url(machine, ui)
+          ui.info("Update server URL to #{machine.config.registration.serverurl}...")
+          machine.communicate.execute("sed -i 's|^serverURL=.*$|serverURL=/usr/share/rhn/#{machine.config.registration.serverurl}|' /etc/sysconfig/rhn/up2date", sudo: true)
+        end
+
+        # @param name [String] the resource file name
+        # @return [String] the absolute path to the resource file
+        def self.resource(name)
+          File.join(resource_root, name)
+        end
+
+        # @return [String] the absolute path to the resource directory
+        def self.resource_root
+          File.expand_path('../../../../../resources', __FILE__)
+        end
+
+        # Build additional rhreg_ks options based on plugin configuration
+        def self.configuration_to_options(config)
+          config.force = true unless config.force
+
+          options = []
+          options << "--profilename='#{config.name}'" if config.name
+          options << "--username='#{config.username}'" if config.username
+          options << "--password='#{config.password}'" if config.password
+          options << "--systemorgid='#{config.org}'" if config.org
+          options << "--serverUrl='#{config.serverurl}'" if config.serverurl
+          options << "--activationkey='#{config.activationkey}'" if config.activationkey
+          options << '--use_eus_channel' if config.use_eus_channel
+          options << '--nohardware' if config.nohardware
+          options << '--nopackages' if config.nopackages
+          options << '--novirtinfo' if config.novirtinfo
+          options << '--norhnsd' if config.norhnsd
+          options << '--force' if config.force
+          options.join(' ')
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/redhat/plugin.rb
+++ b/plugins/guests/redhat/plugin.rb
@@ -82,6 +82,41 @@ module VagrantPlugins
         require_relative 'cap/subscription_manager'
         Cap::SubscriptionManager
       end
+
+      guest_capability('redhat', 'rhn_register') do
+        require_relative 'cap/rhn_register'
+        Cap::RhnRegister
+      end
+
+      guest_capability('redhat', 'rhn_register_registered?') do
+        require_relative 'cap/rhn_register'
+        Cap::RhnRegister
+      end
+
+      guest_capability('redhat', 'rhn_register_register') do
+        require_relative 'cap/rhn_register'
+        Cap::RhnRegister
+      end
+
+      guest_capability('redhat', 'rhn_register_unregister') do
+        require_relative 'cap/rhn_register'
+        Cap::RhnRegister
+      end
+
+      guest_capability('redhat', 'rhn_register_credentials') do
+        require_relative 'cap/rhn_register'
+        Cap::RhnRegister
+      end
+
+      guest_capability('redhat', 'rhn_register_options') do
+        require_relative 'cap/rhn_register'
+        Cap::RhnRegister
+      end
+
+      guest_capability('redhat', 'rhn_register_secrets') do
+        require_relative 'cap/rhn_register'
+        Cap::RhnRegister
+      end
     end
   end
 end

--- a/resources/rhn_unregister.py
+++ b/resources/rhn_unregister.py
@@ -1,39 +1,24 @@
 #!/usr/bin/python
 import argparse
 import xmlrpclib
-from lxml import etree
-import re
+import os.path
 import sys
-
-def unregister(username, password, server_url, id):
-  xmlrpclib.Server(server_url)
-  sc = xmlrpclib.Server(server_url)
-  sk = sc.auth.login(username, password)
-  result = sc.system.deleteSystems(sk,[id])
-  return result
-
-
-def get_system_id():
-  root = etree.parse('/etc/sysconfig/rhn/systemid')
-  system_id = root.xpath("./param/value/struct/member/name[text()='system_id']/../value/string/text()")[0]
-  id = re.search('(?<=ID-)[0-9]+$', system_id).group(0)
-  return int(id)
 
 def main():
   parser = argparse.ArgumentParser(description="Unregister the system from Spacewalk Server, Red Hat Satellite or Red Hat Network Classic.")
-  parser.add_argument("-u", "--username", dest="username", type=str, required=True,
-                      help="The username to register the system with under Spacewalk Server, Red Hat Satellite or Red Hat Network Classic.")
-  parser.add_argument("-p", "--password", dest="password", type=str, required=True,
-                      help="The password associated with the username specified with the --username option. This is an unencrypted password.")
   parser.add_argument("-s", "--serverurl", dest="server_url", type=str, required=True,
                       help="Specify a URL to as the server.")
+  parser.add_argument("-f", "--file", dest="system_id", type=str, default='/etc/sysconfig/rhn/systemid',
+                      help="Specify a path to the RHN systemid file.")
 
   args = parser.parse_args()
 
   try:
-    system_id = get_system_id()
-    if unregister(args.username, args.password, args.server_url, system_id) != 1:
+    if not os.path.exists(args.system_id):
+      print "System is not registered to RHN"
       return 1
+    client =  xmlrpclib.Server(args.server_url)
+    client.system.delete_system(open(args.system_id).read())
   except xmlrpclib.ProtocolError as err:
     print "A fault occurred"
     print "Fault string: %s" % err
@@ -47,7 +32,10 @@ def main():
     print "A fault occurred"
     print "Fault string: %s" % err
     return 1
-
+  except Exception as e:
+    print "A fault occurred"
+    print "Fault: %s" % e
+    return 1
   print "Unregister successful"
   return 0
 

--- a/resources/rhn_unregister.py
+++ b/resources/rhn_unregister.py
@@ -1,0 +1,55 @@
+#!/usr/bin/python
+import argparse
+import xmlrpclib
+from lxml import etree
+import re
+import sys
+
+def unregister(username, password, server_url, id):
+  xmlrpclib.Server(server_url)
+  sc = xmlrpclib.Server(server_url)
+  sk = sc.auth.login(username, password)
+  result = sc.system.deleteSystems(sk,[id])
+  return result
+
+
+def get_system_id():
+  root = etree.parse('/etc/sysconfig/rhn/systemid')
+  system_id = root.xpath("./param/value/struct/member/name[text()='system_id']/../value/string/text()")[0]
+  id = re.search('(?<=ID-)[0-9]+$', system_id).group(0)
+  return int(id)
+
+def main():
+  parser = argparse.ArgumentParser(description="Unregister the system from Spacewalk Server, Red Hat Satellite or Red Hat Network Classic.")
+  parser.add_argument("-u", "--username", dest="username", type=str, required=True,
+                      help="The username to register the system with under Spacewalk Server, Red Hat Satellite or Red Hat Network Classic.")
+  parser.add_argument("-p", "--password", dest="password", type=str, required=True,
+                      help="The password associated with the username specified with the --username option. This is an unencrypted password.")
+  parser.add_argument("-s", "--serverurl", dest="server_url", type=str, required=True,
+                      help="Specify a URL to as the server.")
+
+  args = parser.parse_args()
+
+  try:
+    system_id = get_system_id()
+    if unregister(args.username, args.password, args.server_url, system_id) != 1:
+      return 1
+  except xmlrpclib.ProtocolError as err:
+    print "A fault occurred"
+    print "Fault string: %s" % err
+    return 1
+  except xmlrpclib.Fault as err:
+    print "A fault occurred"
+    print "Fault code: %d" % err.faultCode
+    print "Fault string: %s" % err.faultString
+    return 1
+  except IOError as err:
+    print "A fault occurred"
+    print "Fault string: %s" % err
+    return 1
+
+  print "Unregister successful"
+  return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -1,3 +1,12 @@
+
+LOG_STDOUT="1>/dev/null"
+LOG_STDERR="2>/dev/null"
+
+if [ ${DEBUG:-0} -eq 1 ] ; then
+  LOG_STDOUT=""
+  LOG_STDERR=""
+fi
+
 # Set up test environment
 function setup_tests() {
   check_credentials
@@ -68,7 +77,7 @@ function install_dependencies() {
 #
 #   test_success "ls won't fail" "ls -all"
 function test_success() {
-  eval $2 >&1 >/dev/null
+  eval $2 $LOG_STDOUT $LOG_STDERR
   if [ $? -ne 0 ]; then
     printf "F"
     FAILED=$((FAILED + 1))
@@ -91,7 +100,7 @@ function test_success() {
 #
 #   test_failure "this should fail" "echoo"
 function test_failure() {
-  eval $2 >&1 >/dev/null
+  eval $2 $LOG_STDOUT $LOG_STDERR
   if [ $? -ne 0 ]; then
     SUCCEDED=$((SUCCEDED + 1))
     printf '.'

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -32,6 +32,7 @@ setup_tests
 
 # Test correct username/password and org/activationkey credentials in a multi-machine setup
 clean_up
+export VAGRANT_REGISTRATION_MANAGER=subscription_manager
 export VAGRANT_VAGRANTFILE=$DIR/vagrantfiles/Vagrantfile.rhel_multi_machine
 
 test_success 'vagrant up on RHEL multi_machine setup' 'vagrant up rhel1-valid-credentials'

--- a/tests/run_rhn_register.sh
+++ b/tests/run_rhn_register.sh
@@ -30,6 +30,12 @@ DIR=$(dirname $(readlink -f "$0"))
 
 setup_tests
 
+# Check that we have the server URL to run the test suite
+if [ "$VAGRANT_REGISTRATION_SERVERURL" = "" ]; then
+  echo "VAGRANT_REGISTRATION_SERVERURL needs to be provided."
+  exit 1
+fi
+
 # Test correct username/password and org/activationkey credentials in a multi-machine setup
 clean_up
 export VAGRANT_REGISTRATION_MANAGER=rhn_register

--- a/tests/run_rhn_register.sh
+++ b/tests/run_rhn_register.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# This tests test vagrant-registration plugin running on Fedora
+# with libvirt. If you do not have Vagrant installed or if you
+# have vagrant-libvirt package on your system, Vagrant will be
+# installed or vagrant-libvirt removed respectively. In that case
+# you need sudo to run the tests. If you do not run Fedora, make
+# sure you have Vagrant installed (any provider should do if you
+# add RHEL box called 'rhel-7').
+#
+# IMPORTANT: Tests need valid credentials to actually test
+# registration. This can be provided in form of environment
+# variables.
+#
+# NOTE: This will install a development version of
+# vagrant-registration on your system.
+#
+# == rhn-register
+#
+# For testing RHN Classic on RHEL export
+# VAGRANT_REGISTRATION_USERNAME with VAGRANT_REGISTRATION_PASSWORD
+# for username/password registration and VAGRANT_REGISTRATION_ORG
+# with VAGRANT_REGISTRATION_ACTIVATIONKEY for org/activationkey one.
+#
+
+DIR=$(dirname $(readlink -f "$0"))
+
+# Import test helpers
+. $DIR/helpers.sh
+
+setup_tests
+
+# Test correct username/password and org/activationkey credentials in a multi-machine setup
+clean_up
+export VAGRANT_REGISTRATION_MANAGER=rhn_register
+export VAGRANT_VAGRANTFILE=$DIR/vagrantfiles/Vagrantfile.rhel_multi_machine
+
+test_success 'vagrant up on RHEL multi_machine setup' 'vagrant up rhel1-valid-credentials'
+
+test_success 'first machine is registered with given username/password' \
+            'vagrant ssh rhel1-valid-credentials -c '\''sudo rhn_check'\'''
+
+test_success 'vagrant halt on RHEL multi_machine setup' 'vagrant halt rhel1-valid-credentials'
+test_success 'vagrant halt on RHEL multi_machine setup' 'vagrant destroy'
+test_success 'vagrant up on RHEL multi_machine setup' 'vagrant up rhel2-valid-credentials'
+
+test_success 'second machine is registered with given org/activationkey' \
+            'vagrant ssh rhel2-valid-credentials -c '\''sudo rhn_check'\'''
+
+test_success 'vagrant halt on RHEL multi_machine setup' 'vagrant destroy'
+
+# Test wrong credentials
+clean_up
+export VAGRANT_VAGRANTFILE=$DIR/vagrantfiles/Vagrantfile.rhel_wrong_credentials
+test_failure 'vagrant up on RHEL with wrong credentials should fail' 'vagrant up'
+test_success 'vagrant destroy on RHEL with wrong credentials' 'vagrant destroy'
+
+print_results

--- a/tests/vagrantfiles/Vagrantfile.rhel_multi_machine
+++ b/tests/vagrantfiles/Vagrantfile.rhel_multi_machine
@@ -2,16 +2,19 @@
 
 ENV['VAGRANT_DEFAULT_PROVIDER'] ||= 'libvirt'
 ENV['VAGRANT_REGISTRATION_RHEL_BOX'] ||= 'rhel-7.1'
+ENV['VAGRANT_REGISTRATION_MANAGER'] ||= 'subscription_manager'
 
 Vagrant.configure('2') do |config|
   config.vm.box = ENV['VAGRANT_REGISTRATION_RHEL_BOX']
 
   config.vm.define "rhel1-valid-credentials" do |c|
+    c.registration.manager = ENV['VAGRANT_REGISTRATION_MANAGER']
     c.registration.username = ENV['VAGRANT_REGISTRATION_USERNAME']
     c.registration.password = ENV['VAGRANT_REGISTRATION_PASSWORD']
   end
 
   config.vm.define "rhel2-valid-credentials" do |c|
+    c.registration.manager = ENV['VAGRANT_REGISTRATION_MANAGER']
     c.registration.org = ENV['VAGRANT_REGISTRATION_ORG']
     c.registration.activationkey = ENV['VAGRANT_REGISTRATION_ACTIVATIONKEY']
   end

--- a/tests/vagrantfiles/Vagrantfile.rhel_multi_machine
+++ b/tests/vagrantfiles/Vagrantfile.rhel_multi_machine
@@ -1,4 +1,4 @@
-# Spin 3 RHEL machines that will be registered
+# Spin 2 RHEL machines that will be registered
 
 ENV['VAGRANT_DEFAULT_PROVIDER'] ||= 'libvirt'
 ENV['VAGRANT_REGISTRATION_RHEL_BOX'] ||= 'rhel-7.1'
@@ -11,12 +11,16 @@ Vagrant.configure('2') do |config|
     c.registration.manager = ENV['VAGRANT_REGISTRATION_MANAGER']
     c.registration.username = ENV['VAGRANT_REGISTRATION_USERNAME']
     c.registration.password = ENV['VAGRANT_REGISTRATION_PASSWORD']
+    c.registration.serverurl = ENV['VAGRANT_REGISTRATION_SERVERURL'] if !ENV['VAGRANT_REGISTRATION_SERVERURL'].nil?
+    c.registration.ca_cert = ENV['VAGRANT_REGISTRATION_CA_CERT'] if !ENV['VAGRANT_REGISTRATION_CA_CERT'].nil?
   end
 
   config.vm.define "rhel2-valid-credentials" do |c|
     c.registration.manager = ENV['VAGRANT_REGISTRATION_MANAGER']
     c.registration.org = ENV['VAGRANT_REGISTRATION_ORG']
     c.registration.activationkey = ENV['VAGRANT_REGISTRATION_ACTIVATIONKEY']
+    c.registration.serverurl = ENV['VAGRANT_REGISTRATION_SERVERURL'] if !ENV['VAGRANT_REGISTRATION_SERVERURL'].nil?
+    c.registration.ca_cert = ENV['VAGRANT_REGISTRATION_CA_CERT'] if !ENV['VAGRANT_REGISTRATION_CA_CERT'].nil?
   end
 
 end

--- a/tests/vagrantfiles/Vagrantfile.rhel_wrong_credentials
+++ b/tests/vagrantfiles/Vagrantfile.rhel_wrong_credentials
@@ -11,6 +11,8 @@ Vagrant.configure('2') do |config|
     c.registration.manager = ENV['VAGRANT_REGISTRATION_MANAGER']
     c.registration.username = 'wrong_username'
     c.registration.password = 'wrong_password'
+    c.registration.serverurl = ENV['VAGRANT_REGISTRATION_SERVERURL'] if !ENV['VAGRANT_REGISTRATION_SERVERURL'].nil?
+    c.registration.ca_cert = ENV['VAGRANT_REGISTRATION_CA_CERT'] if !ENV['VAGRANT_REGISTRATION_CA_CERT'].nil?
   end
 
 end

--- a/tests/vagrantfiles/Vagrantfile.rhel_wrong_credentials
+++ b/tests/vagrantfiles/Vagrantfile.rhel_wrong_credentials
@@ -2,11 +2,13 @@
 
 ENV['VAGRANT_DEFAULT_PROVIDER'] ||= 'libvirt'
 ENV['VAGRANT_REGISTRATION_RHEL_BOX'] ||= 'rhel-7.1'
+ENV['VAGRANT_REGISTRATION_MANAGER'] ||= 'subscription_manager'
 
 Vagrant.configure('2') do |config|
   config.vm.box = ENV['VAGRANT_REGISTRATION_RHEL_BOX']
 
   config.vm.define "rhel1-wrong-credentials" do |c|
+    c.registration.manager = ENV['VAGRANT_REGISTRATION_MANAGER']
     c.registration.username = 'wrong_username'
     c.registration.password = 'wrong_password'
   end

--- a/vagrant-registration.gemspec
+++ b/vagrant-registration.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   all_files      = Dir.chdir(root_path) {
     Dir.glob('lib/**/{*,.*}') +
     Dir.glob('plugins/**/{*,.*}') +
+    Dir.glob('resources/**/{*,.*}') +
     ['Rakefile', 'Gemfile', 'README.md', 'CHANGELOG.md', 'LICENSE.md', 'vagrant-registration.gemspec']
   }
   all_files.reject! { |file| ['.', '..'].include?(File.basename(file)) }


### PR DESCRIPTION
This change adds the `rhn-register` manager implementation required for registering a system with the "Spacewalk Server", "Red Hat Satellite" or "Red Hat Network Classic"

The unregister will remove the `/etc/sysconfig/rhn/systemid` file to make sure the system will not think anymore that it is part of RHN. The registered system is removed from the "Spacewalk Server", "Red Hat Satellite" or "Red Hat Network Classic" using the `deleteSystems` api call only if the username/password is provided to the vagrant VM configuration.

Other changes included in the pull request:
-  Add support to show vagrant output on console while executing tests script.
- Added test script for rhn_register manager
- Make subscription service URL and CA certificate configurable in test run script.