### PR TITLE
Execute registration earlier with vbguest plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.gem
 *.rbc
+*~
+*.swp
 /.config
 /coverage/
 /InstalledFiles
@@ -9,6 +11,7 @@
 /test/version_tmp/
 /tmp/
 .idea/
+
 ## Specific to RubyMotion:
 .dat*
 .repl_history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - Print warning if specifically selected manager is not available
+- Support running alongside vagrant-vbguest
 
 ## 1.0.1
 

--- a/lib/vagrant-registration/action/register.rb
+++ b/lib/vagrant-registration/action/register.rb
@@ -11,6 +11,8 @@ module VagrantPlugins
         end
 
         def call(env)
+          @app.call(env) unless Plugin.vbguest_plugin?
+
           # Configuration from Vagrantfile
           config = env[:machine].config.registration
           machine = env[:machine]
@@ -36,7 +38,8 @@ module VagrantPlugins
           end
 
           @logger.debug('Registration is skipped due to the configuration') if config.skip
-          @app.call(env)
+
+          @app.call(env) if Plugin.vbguest_plugin?
         end
 
         private

--- a/lib/vagrant-registration/action/register.rb
+++ b/lib/vagrant-registration/action/register.rb
@@ -11,6 +11,9 @@ module VagrantPlugins
         end
 
         def call(env)
+          # Vbguest plugin (if present) is called next. Therefore registration
+          # needs to be done first. This does not work with the default
+          # 'action_register' hook.
           @app.call(env) unless Plugin.vbguest_plugin?
 
           # Configuration from Vagrantfile

--- a/lib/vagrant-registration/action/register.rb
+++ b/lib/vagrant-registration/action/register.rb
@@ -11,8 +11,6 @@ module VagrantPlugins
         end
 
         def call(env)
-          @app.call(env)
-
           # Configuration from Vagrantfile
           config = env[:machine].config.registration
           machine = env[:machine]
@@ -38,6 +36,7 @@ module VagrantPlugins
           end
 
           @logger.debug('Registration is skipped due to the configuration') if config.skip
+          @app.call(env)
         end
 
         private

--- a/lib/vagrant-registration/plugin.rb
+++ b/lib/vagrant-registration/plugin.rb
@@ -16,7 +16,7 @@ module VagrantPlugins
       class << self
         def register(hook)
           setup_logging
-          hook.after(::Vagrant::Action::Builtin::SyncedFolders,
+          hook.after(::Vagrant::Action::Builtin::WaitForCommunicator,
                      VagrantPlugins::Registration::Action.action_register)
         end
 

--- a/lib/vagrant-registration/plugin.rb
+++ b/lib/vagrant-registration/plugin.rb
@@ -16,8 +16,14 @@ module VagrantPlugins
       class << self
         def register(hook)
           setup_logging
-          hook.after(::Vagrant::Action::Builtin::WaitForCommunicator,
-                     VagrantPlugins::Registration::Action.action_register)
+
+          if vbguest_plugin?
+            hook.before(VagrantVbguest::Middleware,
+                                 VagrantPlugins::Registration::Action.action_register)
+          else
+            hook.after(::Vagrant::Action::Builtin::SyncedFolders,
+                               VagrantPlugins::Registration::Action.action_register)
+          end
         end
 
         def unregister_on_halt(hook)
@@ -73,6 +79,13 @@ module VagrantPlugins
           logger.level = level
           logger = nil
         end
+      end
+
+      def self.vbguest_plugin?
+        @@vbguest_plugin ||= (
+          defined?(VagrantPlugins::ProviderVirtualBox::Provider) &&
+          defined?(VagrantVbguest::Middleware)
+        )
       end
     end
   end

--- a/lib/vagrant-registration/plugin.rb
+++ b/lib/vagrant-registration/plugin.rb
@@ -14,11 +14,17 @@ module VagrantPlugins
   module Registration
     class Plugin < Vagrant.plugin('2')
       class << self
+
+        # Vbguest plugin updates GuestAdditions for VirtualBox before
+        # '::Vagrant::Action::Builtin::SyncedFolders' and therefore needs
+        # to be registered. Prepending Vbguest hook ensures that, but this
+        # is done only with Vbguest plugin and VirtualBox provider. In other
+        # cases the behavior is unchanged.
         def register(hook)
           setup_logging
 
           if vbguest_plugin?
-            hook.before(VagrantVbguest::Middleware,
+            hook.before(::VagrantVbguest::Middleware,
                                  VagrantPlugins::Registration::Action.action_register)
           else
             hook.after(::Vagrant::Action::Builtin::SyncedFolders,
@@ -81,6 +87,7 @@ module VagrantPlugins
         end
       end
 
+      # Determines if both VirtualBox provider and Vbguest plugin are present.
       def self.vbguest_plugin?
         @@vbguest_plugin ||= (
           defined?(VagrantPlugins::ProviderVirtualBox::Provider) &&


### PR DESCRIPTION
Earlier subscription grants other plugins access to services, e.g. vbguest plugin can run `yum install ...` on boot.
Default behavior is changed only when both vbguest plugin and virtualbox provider are defined.
Fixes issue #40.