### PR TITLE
Fix adjust_arguments() to handle various types correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Print warning if specifically selected manager is not available
 - Support running alongside vagrant-vbguest
 - Support rhn_register manager
+- Fix: Handle various types of configuration option values, issue #48
 
 ## 1.0.1
 

--- a/lib/vagrant-registration/config.rb
+++ b/lib/vagrant-registration/config.rb
@@ -34,9 +34,11 @@ module VagrantPlugins
         @conf = OpenStruct.new if @conf == UNSET_VALUE
       end
 
+      # Serialize strings, nil and boolean values, symbols, arrays and hashes
+      # to be used within eval()
       def adjust_arguments(args)
         return '' if args.size < 1
-        args.map { |a| a.is_a?(String) ? "'#{a}'" : a }.join(',')
+        args.inspect[1..-2]
       end
     end
   end


### PR DESCRIPTION
Support strings, nil and boolean values, symbols, arrays and hashes
as a registration configuration option values.

Resolves issue #48.
Uses inspect() to serialize given object.