### PR TITLE
Handle exception when registration failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Support running alongside vagrant-vbguest
 - Support rhn_register manager
 - Fix: Handle various types of configuration option values, issue #48
+- Fix: Hide password on registration failure, issue #47
 
 ## 1.0.1
 

--- a/plugins/guests/redhat/cap/subscription_manager.rb
+++ b/plugins/guests/redhat/cap/subscription_manager.rb
@@ -18,15 +18,15 @@ module VagrantPlugins
         def self.subscription_manager_register(machine, ui)
           subscription_manager_upload_certificate(machine, ui) if machine.config.registration.ca_cert
           command = "subscription-manager register #{configuration_to_options(machine.config.registration)}"
-          error = ''
 
           # Handle exception to avoid displaying password
           begin
+            error = String.new
             machine.communicate.sudo("cmd=$(#{command}); if [ \"$?\" != \"0\" ]; then " \
-              + "echo $cmd | grep 'This system is already registered' || (echo $cmd 1>&2 && exit 1) ; fi") do |_, data|
-			    error += "#{data}\n"
+              + "echo $cmd | grep 'This system is already registered' || (echo $cmd 1>&2 && exit 1) ; fi") do |type, data|
+                error += "#{data}\n" if type == :stderr
             end
-          rescue Vagrant::Errors::VagrantError => e
+          rescue Vagrant::Errors::VagrantError
             raise Vagrant::Errors::VagrantError.new, error.squeeze("\n")
           end
         end

--- a/plugins/guests/redhat/cap/subscription_manager.rb
+++ b/plugins/guests/redhat/cap/subscription_manager.rb
@@ -18,7 +18,17 @@ module VagrantPlugins
         def self.subscription_manager_register(machine, ui)
           subscription_manager_upload_certificate(machine, ui) if machine.config.registration.ca_cert
           command = "subscription-manager register #{configuration_to_options(machine.config.registration)}"
-          machine.communicate.execute("cmd=$(#{command}); if [ \"$?\" != \"0\" ]; then echo $cmd | grep 'This system is already registered' || (echo $cmd 1>&2 && exit 1) ; fi", sudo: true)
+          error = ''
+
+          # Handle exception to avoid displaying password
+          begin
+            machine.communicate.sudo("cmd=$(#{command}); if [ \"$?\" != \"0\" ]; then " \
+              + "echo $cmd | grep 'This system is already registered' || (echo $cmd 1>&2 && exit 1) ; fi") do |_, data|
+			    error += "#{data}\n"
+            end
+          rescue Vagrant::Errors::VagrantError => e
+            raise Vagrant::Errors::VagrantError.new, error.squeeze("\n")
+          end
         end
 
         # Upload provided CA cert to the standard /etc/rhsm/ca path on the guest


### PR DESCRIPTION
On subscription failure is raised an error containing credentials
in clear text, therefore we raise an error with the response
from subscription-manager instead.

Resolves issue #47.