### PR TITLE
Fix auto-attach and force option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Fix: option auto-attach to accept user-defined values
+
 ## 1.1.0
 
 - Print warning if specifically selected manager is not available

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-- Fix: option auto-attach to accept user-defined values
+- Fix: options auto-attach and force to accept user-defined values
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-- Fix: options auto-attach and force to accept user-defined values
+- Fix: Allow auto-attach and force options to be configured
 
 ## 1.1.0
 

--- a/plugins/guests/redhat/cap/rhn_register.rb
+++ b/plugins/guests/redhat/cap/rhn_register.rb
@@ -116,7 +116,7 @@ module VagrantPlugins
 
         # Build additional rhreg_ks options based on the plugin configuration
         def self.configuration_to_options(config)
-          config.force = true unless config.force
+          config.force = true if config.force.nil?
 
           options = []
           options << "--profilename='#{config.name}'" if config.name

--- a/plugins/guests/redhat/cap/subscription_manager.rb
+++ b/plugins/guests/redhat/cap/subscription_manager.rb
@@ -88,7 +88,7 @@ module VagrantPlugins
           if config.org && config.activationkey
             config.auto_attach = false
           else
-            config.auto_attach = true unless config.auto_attach
+            config.auto_attach = true if config.auto_attach.nil?
           end
 
           options = []

--- a/plugins/guests/redhat/cap/subscription_manager.rb
+++ b/plugins/guests/redhat/cap/subscription_manager.rb
@@ -82,7 +82,7 @@ module VagrantPlugins
 
         # Build additional subscription-manager options based on plugin configuration
         def self.configuration_to_options(config)
-          config.force = true unless config.force
+          config.force = true if config.force.nil?
 
           # --auto-attach cannot be used in case of org/activationkey registration
           if config.org && config.activationkey


### PR DESCRIPTION
Options auto-attach and force should accept user-defined values.