### PR TITLE
Remove shebang from python script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - Fix: Allow auto-attach and force options to be configured
+- Fix: Remove unnecessary shebang from python script
 
 ## 1.1.0
 
@@ -9,7 +10,6 @@
 - Support rhn_register manager
 - Fix: Handle various types of configuration option values, issue #48
 - Fix: Hide password on registration failure, issue #47
-- Fix: Remove unnecessary shebang from python script
 
 ## 1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Support rhn_register manager
 - Fix: Handle various types of configuration option values, issue #48
 - Fix: Hide password on registration failure, issue #47
+- Fix: Remove unnecessary shebang from python script
 
 ## 1.0.1
 

--- a/resources/rhn_unregister.py
+++ b/resources/rhn_unregister.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 import argparse
 import xmlrpclib
 import os.path


### PR DESCRIPTION
Shebang is unnecessary as python script is executed indirectly on guest.