### PR TITLE
Remove subscription_manager_upload_certificate from capabilities

### DIFF
--- a/plugins/guests/redhat/plugin.rb
+++ b/plugins/guests/redhat/plugin.rb
@@ -58,11 +58,6 @@ module VagrantPlugins
         Cap::SubscriptionManager
       end
 
-      guest_capability('redhat', 'subscription_manager_upload_certificate') do
-        require_relative 'cap/subscription_manager'
-        Cap::SubscriptionManager
-      end
-
       guest_capability('redhat', 'subscription_manager_unregister') do
         require_relative 'cap/subscription_manager'
         Cap::SubscriptionManager


### PR DESCRIPTION
The method `subscription_manager_upload_certificate` of class `SubscriptionManager` is private and not required to be registered as capability.