### PR TITLE
Use machine.communicate.sudo method instead of execute

### DIFF
--- a/plugins/guests/redhat/cap/rhn_register.rb
+++ b/plugins/guests/redhat/cap/rhn_register.rb
@@ -4,15 +4,15 @@ module VagrantPlugins
       class RhnRegister
         # Test that the machine is already registered
         def self.rhn_register_registered?(machine)
-          true if machine.communicate.execute('/usr/sbin/rhn_check', sudo: true)
+          true if machine.communicate.sudo('/usr/sbin/rhn_check')
         rescue
           false
         end
 
         # Test that we have rhn installed
         def self.rhn_register(machine)
-          machine.communicate.test('/usr/sbin/rhn_check --version', sudo: true) &&
-          machine.communicate.test('/usr/sbin/rhnreg_ks --version', sudo: true)
+          machine.communicate.test('/usr/sbin/rhn_check --version') &&
+          machine.communicate.test('/usr/sbin/rhnreg_ks --version')
         end
 
         # Register the machine using 'rhnreg_ks' command, config is (Open)Struct
@@ -81,15 +81,15 @@ module VagrantPlugins
             if File.exist?(machine.config.registration.ca_cert)
               # Make sure the provided CA certificate file will be configured
               cert_file_name = File.basename(machine.config.registration.ca_cert)
-              cert_file_content = File.read(machine.config.registration.ca_cert)
-              machine.communicate.execute("echo '#{cert_file_content}' > /usr/share/rhn/#{cert_file_name}", sudo: true)
+              cert_file_content = File.read(machine.config.registration.ca_cert, tmp)
+              machine.communicate.sudo("echo '#{cert_file_content}' > /usr/share/rhn/#{cert_file_name}")
             else
               ui.warn("WARNING: Provided CA certificate file #{machine.config.registration.ca_cert} does not exist, skipping")
             end
           end
           # Make sure the correct CA certificate file is always configured
           ui.info("Updating CA certificate to /usr/share/rhn/#{cert_file_name}`...")
-          machine.communicate.execute("sed -i 's|^sslCACert\s*=.*$|sslCACert=/usr/share/rhn/#{cert_file_name}|g' /etc/sysconfig/rhn/up2date", sudo: true)
+          machine.communicate.sudo("sed -i 's|^sslCACert\s*=.*$|sslCACert=/usr/share/rhn/#{cert_file_name}|g' /etc/sysconfig/rhn/up2date")
         end
 
         # Build registration command that skips registration if the system is registered
@@ -101,7 +101,7 @@ module VagrantPlugins
         # provided server URL
         def self.rhn_register_server_url(machine, ui)
           ui.info("Update server URL to #{machine.config.registration.serverurl}...")
-          machine.communicate.execute("sed -i 's|^serverURL=.*$|serverURL=/usr/share/rhn/#{machine.config.registration.serverurl}|' /etc/sysconfig/rhn/up2date", sudo: true)
+          machine.communicate.sudo("sed -i 's|^serverURL=.*$|serverURL=/usr/share/rhn/#{machine.config.registration.serverurl}|' /etc/sysconfig/rhn/up2date")
         end
 
         # The absolute path to the resource file

--- a/plugins/guests/redhat/cap/subscription_manager.rb
+++ b/plugins/guests/redhat/cap/subscription_manager.rb
@@ -4,14 +4,14 @@ module VagrantPlugins
       class SubscriptionManager
         # Test that the machine is already registered
         def self.subscription_manager_registered?(machine)
-          false if machine.communicate.execute("/usr/sbin/subscription-manager list --consumed | grep 'No consumed subscription pools to list'", sudo: true)
+          false if machine.communicate.sudo("/usr/sbin/subscription-manager list --consumed | grep 'No consumed subscription pools to list'")
         rescue
           true
         end
 
         # Test that we have subscription-manager installed
         def self.subscription_manager(machine)
-          machine.communicate.test('/usr/sbin/subscription-manager', sudo: true)
+          machine.communicate.test('/usr/sbin/subscription-manager')
         end
 
         # Register the machine using 'register' option, config is (Open)Struct
@@ -34,7 +34,7 @@ module VagrantPlugins
 
         # Unregister the machine using 'unregister' option
         def self.subscription_manager_unregister(machine)
-          machine.communicate.execute('subscription-manager unregister || :', sudo: true)
+          machine.communicate.sudo('subscription-manager unregister || :')
         end
 
         # Return required configuration options for subscription-manager
@@ -69,9 +69,9 @@ module VagrantPlugins
             cert_file_content = File.read(machine.config.registration.ca_cert)
             cert_file_name = File.basename(machine.config.registration.ca_cert)
             cert_file_name = "#{cert_file_name}.pem" unless cert_file_name.end_with? '.pem'
-            machine.communicate.execute("echo '#{cert_file_content}' > /etc/rhsm/ca/#{cert_file_name}", sudo: true)
+            machine.communicate.sudo("echo '#{cert_file_content}' > /etc/rhsm/ca/#{cert_file_name}")
             ui.info('Setting repo_ca_cert option in /etc/rhsm/rhsm.conf...')
-            machine.communicate.execute("sed -i 's|^repo_ca_cert\s*=.*|repo_ca_cert = /etc/rhsm/ca/#{cert_file_name}|g' /etc/rhsm/rhsm.conf", sudo: true)
+            machine.communicate.sudo("sed -i 's|^repo_ca_cert\s*=.*|repo_ca_cert = /etc/rhsm/ca/#{cert_file_name}|g' /etc/rhsm/rhsm.conf")
           else
             ui.warn("WARNING: Provided CA certificate file #{machine.config.registration.ca_cert} does not exist, skipping")
           end


### PR DESCRIPTION
Make code cleaner by using method `machine.communicate.sudo` instead of `machine.communicate.execute` with `sudo: true` parameter.

Also, the test command call doesn't need to be executed as root.