### PR TITLE
Fixes #60: rhn_register upload certificate fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix: Allow auto-attach and force options to be configured
 - Fix: Remove unnecessary shebang from python script
 - Support for attaching to specified subscription pool(s), issue #36
+- Fix: rhn_register upload certificate fails, issue #60
 
 ## 1.1.0
 

--- a/plugins/guests/redhat/cap/rhn_register.rb
+++ b/plugins/guests/redhat/cap/rhn_register.rb
@@ -81,7 +81,7 @@ module VagrantPlugins
             if File.exist?(machine.config.registration.ca_cert)
               # Make sure the provided CA certificate file will be configured
               cert_file_name = File.basename(machine.config.registration.ca_cert)
-              cert_file_content = File.read(machine.config.registration.ca_cert, tmp)
+              cert_file_content = File.read(machine.config.registration.ca_cert)
               machine.communicate.execute("echo '#{cert_file_content}' > /usr/share/rhn/#{cert_file_name}", sudo: true)
             else
               ui.warn("WARNING: Provided CA certificate file #{machine.config.registration.ca_cert} does not exist, skipping")


### PR DESCRIPTION
Removed undefined local variable `tmp` from the `File.read` call to fix #60 