### PR TITLE
`vagrant destroy` not triggering subscription deactivation and removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- Fix: `vagrant destroy` not triggering subscription deactivation and removal, issue #57
 - Fix: Allow auto-attach and force options to be configured
 - Fix: Remove unnecessary shebang from python script
 - Support for attaching to specified subscription pool(s), issue #36

--- a/lib/vagrant-registration/action/unregister_on_destroy.rb
+++ b/lib/vagrant-registration/action/unregister_on_destroy.rb
@@ -14,7 +14,7 @@ module VagrantPlugins
           config = env[:machine].config.registration
           guest = env[:machine].guest
 
-          if capabilities_provided?(guest) && manager_installed?(guest) && !config.skip
+          if capabilities_provided?(guest) && manager_installed?(guest, env[:ui]) && !config.skip
             env[:ui].info('Unregistering box with vagrant-registration...')
             guest.capability(:registration_unregister)
           end
@@ -42,8 +42,8 @@ module VagrantPlugins
         end
 
         # Check if selected registration manager is installed
-        def manager_installed?(guest)
-          if guest.capability(:registration_manager_installed)
+        def manager_installed?(guest, ui)
+          if guest.capability(:registration_manager_installed, ui)
             true
           else
             @logger.debug('Registration manager not found on guest')

--- a/lib/vagrant-registration/action/unregister_on_halt.rb
+++ b/lib/vagrant-registration/action/unregister_on_halt.rb
@@ -14,7 +14,7 @@ module VagrantPlugins
           config = env[:machine].config.registration
           guest = env[:machine].guest
 
-          if capabilities_provided?(guest) && manager_installed?(guest) && !config.skip && config.unregister_on_halt
+          if capabilities_provided?(guest) && manager_installed?(guest, env[:ui]) && !config.skip && config.unregister_on_halt
             env[:ui].info('Unregistering box with vagrant-registration...')
             guest.capability(:registration_unregister)
           end
@@ -43,8 +43,8 @@ module VagrantPlugins
         end
 
         # Check if selected registration manager is installed
-        def manager_installed?(guest)
-          if guest.capability(:registration_manager_installed)
+        def manager_installed?(guest, ui)
+          if guest.capability(:registration_manager_installed, ui)
             true
           else
             @logger.debug('Registration manager not found on guest')


### PR DESCRIPTION
This pull request fixes issue #57 

`ui` parameter for method `manager_installed?` was added only for `register` action to be passed on to `registration_manager_installed` and was missing for `unregister_on_halt` and `unregister_on_destroy`.