### PR TITLE
Fix #90: Apply locale based messaging

### DIFF
--- a/lib/vagrant-registration.rb
+++ b/lib/vagrant-registration.rb
@@ -13,5 +13,7 @@ module VagrantPlugins
 
     # Temporally load the extra capability files for Red Hat
     load(File.join(source_root, 'plugins/guests/redhat/plugin.rb'))
+    # Default I18n to load the en locale
+    I18n.load_path << File.expand_path('locales/en.yml', source_root)
   end
 end

--- a/lib/vagrant-registration/action/register.rb
+++ b/lib/vagrant-registration/action/register.rb
@@ -17,14 +17,14 @@ module VagrantPlugins
           guest = env[:machine].guest
 
           if should_register?(machine, env[:ui])
-            env[:ui].info('Registering box with vagrant-registration...')
+            env[:ui].info I18n.t('registration.action.register.registration_info')
             check_configuration_options(machine, env[:ui])
 
             unless credentials_provided? machine
-              @logger.debug('Credentials for registration not provided')
+              @logger.debug I18n.t('registration.action.register.no_credentials')
 
               # Offer to register ATM or skip
-              register_now = env[:ui].ask('Would you like to register the system now (default: yes)? [y|n]')
+              register_now = env[:ui].ask I18n.t('registration.action.register.prompt')
 
               if register_now == 'n'
                 config.skip = true
@@ -35,7 +35,7 @@ module VagrantPlugins
             guest.capability(:registration_register, env[:ui]) unless config.skip
           end
 
-          @logger.debug('Registration is skipped due to the configuration') if config.skip
+          @logger.debug(I18n.t('registration.action.register.skip_due_config')) if config.skip
 
           # Call next middleware in chain
           @app.call(env)
@@ -59,8 +59,8 @@ module VagrantPlugins
           options = machine.config.registration.conf.each_pair.map { |pair| pair[0] }
 
           if unsupported_options_provided?(manager, available_options, options, ui)
-            ui.warn("WARNING: #{manager} supports only the following options:" \
-                    "\nWARNING: #{available_options.join(', ')}")
+            ui.warn(I18n.t('registration.action.register.options_support_warning',
+                           manager: manager, options: available_options.join(', ')))
           end
         end
 
@@ -69,7 +69,8 @@ module VagrantPlugins
           warned = false
           options.each do |option|
             unless available_options.include? option
-              ui.warn("WARNING: #{option} option is not supported for #{manager}")
+              ui.warn(I18n.t('registration.action.register.unsupported_option',
+                             manager: manager, option: option))
               warned = true
             end
           end
@@ -83,7 +84,7 @@ module VagrantPlugins
              guest.capability?(:registration_registered?)
             true
           else
-            @logger.debug('Registration is skipped due to the missing guest capability')
+            @logger.debug I18n.t('registration.action.register.skip_missing_guest_capability')
             false
           end
         end
@@ -93,7 +94,7 @@ module VagrantPlugins
           if guest.capability(:registration_manager_installed, ui)
             true
           else
-            @logger.debug('Registration manager not found on guest')
+            @logger.debug I18n.t('registration.action.manager_not_found')
             false
           end
         end

--- a/lib/vagrant-registration/action/unregister_on_destroy.rb
+++ b/lib/vagrant-registration/action/unregister_on_destroy.rb
@@ -15,17 +15,17 @@ module VagrantPlugins
           guest = env[:machine].guest
 
           if capabilities_provided?(guest) && manager_installed?(guest, env[:ui]) && !config.skip
-            env[:ui].info('Unregistering box with vagrant-registration...')
+            env[:ui].info I18n.t('registration.action.unregister.unregistration_info')
             guest.capability(:registration_unregister)
           end
 
-          @logger.debug('Unregistration is skipped due to the configuration') if config.skip
+          @logger.debug(I18n.t('registration.action.unregister.skip_due_config')) if config.skip
           @app.call(env)
 
         # Guest might not be available after halting, so log the exception and continue
         rescue => e
           @logger.info(e)
-          @logger.debug('Guest is not available, ignore unregistration')
+          @logger.debug I18n.t('registration.action.unregister.guest_unavailable')
           @app.call(env)
         end
 
@@ -36,7 +36,7 @@ module VagrantPlugins
           if guest.capability?(:registration_unregister) && guest.capability?(:registration_manager_installed)
             true
           else
-            @logger.debug('Unregistration is skipped due to the missing guest capability')
+            @logger.debug I18n.t('registration.action.unregister.skip_missing_guest_capability')
             false
           end
         end
@@ -46,7 +46,7 @@ module VagrantPlugins
           if guest.capability(:registration_manager_installed, ui)
             true
           else
-            @logger.debug('Registration manager not found on guest')
+            @logger.debug I18n.t('registration.action.manager_not_found')
             false
           end
         end

--- a/lib/vagrant-registration/action/unregister_on_halt.rb
+++ b/lib/vagrant-registration/action/unregister_on_halt.rb
@@ -15,18 +15,18 @@ module VagrantPlugins
           guest = env[:machine].guest
 
           if capabilities_provided?(guest) && manager_installed?(guest, env[:ui]) && !config.skip && config.unregister_on_halt
-            env[:ui].info('Unregistering box with vagrant-registration...')
+            env[:ui].info I18n.t('registration.action.unregister.unregistration_info')
             guest.capability(:registration_unregister)
           end
 
-          @logger.debug('Unregistration is skipped due to the configuration') if config.skip
-          @logger.debug('Unregistration is skipped on halt due to the configuration') unless config.unregister_on_halt
+          @logger.debug(I18n.t('registration.action.unregister.skip_due_config')) if config.skip
+          @logger.debug(I18n.t('registration.action.unregister.skip_on_halt_due_config')) unless config.unregister_on_halt
           @app.call(env)
 
         # Guest might not be available after halting, so log the exception and continue
         rescue => e
           @logger.info(e)
-          @logger.debug('Guest is not available, ignore unregistration')
+          @logger.debug I18n.t('registration.action.unregister.guest_unavailable')
           @app.call(env)
         end
 
@@ -37,7 +37,7 @@ module VagrantPlugins
           if guest.capability?(:registration_unregister) && guest.capability?(:registration_manager_installed)
             true
           else
-            @logger.debug('Unregistration is skipped due to the missing guest capability')
+            @logger.debug I18n.t('registration.action.unregister.skip_missing_guest_capability')
             false
           end
         end
@@ -47,7 +47,7 @@ module VagrantPlugins
           if guest.capability(:registration_manager_installed, ui)
             true
           else
-            @logger.debug('Registration manager not found on guest')
+            @logger.debug I18n.t('registration.action.manager_not_found')
             false
           end
         end

--- a/lib/vagrant-registration/config.rb
+++ b/lib/vagrant-registration/config.rb
@@ -16,13 +16,13 @@ module VagrantPlugins
         @conf.skip = false unless @conf.skip
         # Unregister on halt by default
         @conf.unregister_on_halt = true if @conf.unregister_on_halt.nil?
-        @logger.info "Final registration configuration: #{@conf.inspect}"
+        @logger.info I18n.t('registration.config.final_message', conf: @conf.inspect)
       end
 
       def method_missing(method_sym, *arguments, &block)
         get_config
         command = "@conf.#{method_sym} #{adjust_arguments(arguments)}"
-        @logger.info "Evaluating registration configuration: #{command}"
+        @logger.info I18n.t('registration.config.method_missing_command', command: command)
         eval command
       end
 

--- a/lib/vagrant-registration/plugin.rb
+++ b/lib/vagrant-registration/plugin.rb
@@ -7,14 +7,13 @@ end
 # This is a sanity check to make sure no one is attempting to install
 # this into an early Vagrant version.
 if Vagrant::VERSION < '1.2.0'
-  fail 'The Vagrant RHEL plugin is only compatible with Vagrant 1.2+.'
+  fail I18n.t('registration.plugin.compatible_message')
 end
 
 module VagrantPlugins
   module Registration
     class Plugin < Vagrant.plugin('2')
       class << self
-
         # vagrant-vbguest plugin updates GuestAdditions for VirtualBox
         # and therefore needs to be run after the box got registered.
         # See https://github.com/projectatomic/adb-vagrant-registration/issues/69
@@ -57,11 +56,8 @@ module VagrantPlugins
         end
       end
 
-      name 'Registration'
-      description <<-DESC
-      This plugin adds register and unregister functionality to Vagrant Guests that
-      support the capability
-      DESC
+      name I18n.t('registration.plugin.name')
+      description I18n.t('registration.plugin.description')
 
       action_hook(:registration_register, :machine_action_up, &method(:register))
       action_hook(:registration_register, :machine_action_provision, &method(:register))

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,0 +1,29 @@
+en:
+  registration:
+    config:
+      final_message: 'Final registration configuration: %{conf}'
+      method_missing_command: 'Evaluating registration configuration: %{command}'
+    plugin:
+      compatible_message: 'The Vagrant RHEL plugin is only compatible with Vagrant 1.2+.'
+      name: 'Registration'
+      description: |-
+        This plugin adds register and unregister functionality to Vagrant Guests that
+        support the capability
+    action:
+      manager_not_found: 'Registration manager not found on guest'
+      register:
+        registration_info: 'Registering box with vagrant-registration...'
+        no_credentials: 'Credentials for registration not provided'
+        prompt: 'Would you like to register the system now (default: yes)? [y|n]'
+        skip_due_config: 'Registration is skipped due to the configuration'
+        options_support_warning: |-
+          WARNING: %{manager} supports only the following options:
+          WARNING: %{options}"
+        unsupported_option: "WARNING: %{option} option is not supported for %{manager}"
+        skip_missing_guest_capability: 'Registration is skipped due to the missing guest capability'
+      unregister:
+        unregistration_info: 'Unregistering box with vagrant-registration...'
+        skip_due_config: 'Unregistration is skipped due to the configuration'
+        skip_on_halt_due_config: 'Unregistration is skipped on halt due to the configuration'
+        guest_unavailable: 'Guest is not available, ignore unregistration'
+        skip_missing_guest_capability: 'Unregistration is skipped due to the missing guest capability'

--- a/vagrant-registration.gemspec
+++ b/vagrant-registration.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   all_files      = Dir.chdir(root_path) do
     Dir.glob('lib/**/{*,.*}') +
     Dir.glob('plugins/**/{*,.*}') +
+    Dir.glob('locales/**/{*,.*}') +
     Dir.glob('resources/**/{*,.*}') +
     ['Rakefile', 'Gemfile', 'README.md', 'CHANGELOG.md', 'LICENSE.md', 'vagrant-registration.gemspec']
   end
@@ -49,5 +50,4 @@ Gem::Specification.new do |s|
   s.files         = unignored_files
   s.executables   = unignored_files.map { |f| f[/^bin\/(.*)/, 1] }.compact
   s.require_path  = 'lib'
-
 end


### PR DESCRIPTION
Tested locally with CDK 2.1, registration and unregistration works fine. 
Unit tests passing.